### PR TITLE
oracle: accept pre-packed trait membership messages

### DIFF
--- a/contracts/ArtblocksTraitOracleMessages.sol
+++ b/contracts/ArtblocksTraitOracleMessages.sol
@@ -16,10 +16,25 @@ struct SetFeatureInfoMessage {
 
 struct AddTraitMembershipsMessage {
     uint256 traitId;
-    uint256[] tokenIds;
+    TraitMembershipWord[] words;
+}
+
+/// A set of token IDs within a multiple-of-256 block.
+struct TraitMembershipWord {
+    /// This set describes membership for tokens between `wordIndex * 256`
+    /// (inclusive) and `(wordIndex + 1) * 256` (exclusive), with IDs relative
+    /// to the start of the project.
+    uint256 wordIndex;
+    /// A 256-bit mask of tokens such that `mask[_i]` is set if token
+    /// `wordIndex * 256 + _i` (relative to the start of the project) is in the
+    /// set.
+    uint256 mask;
 }
 
 library ArtblocksTraitOracleMessages {
+    using ArtblocksTraitOracleMessages for TraitMembershipWord;
+    using ArtblocksTraitOracleMessages for TraitMembershipWord[];
+
     bytes32 internal constant TYPEHASH_SET_PROJECT_INFO =
         keccak256(
             "SetProjectInfoMessage(uint256 projectId,uint256 version,string projectName,uint256 size)"
@@ -30,8 +45,10 @@ library ArtblocksTraitOracleMessages {
         );
     bytes32 internal constant TYPEHASH_ADD_TRAIT_MEMBERSHIPS =
         keccak256(
-            "AddTraitMembershipsMessage(uint256 traitId,uint256[] tokenIds)"
+            "AddTraitMembershipsMessage(uint256 traitId,TraitMembershipWord[] words)TraitMembershipWord(uint256 wordIndex,uint256 mask)"
         );
+    bytes32 internal constant TYPEHASH_TRAIT_MEMBERSHIP_WORD =
+        keccak256("TraitMembershipWord(uint256 wordIndex,uint256 mask)");
 
     function structHash(SetProjectInfoMessage memory _self)
         internal
@@ -76,8 +93,35 @@ library ArtblocksTraitOracleMessages {
                 abi.encodePacked(
                     TYPEHASH_ADD_TRAIT_MEMBERSHIPS,
                     _self.traitId,
-                    keccak256(abi.encodePacked(_self.tokenIds))
+                    _self.words.structHash()
                 )
             );
+    }
+
+    function structHash(TraitMembershipWord memory _self)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encode(
+                    TYPEHASH_TRAIT_MEMBERSHIP_WORD,
+                    _self.wordIndex,
+                    _self.mask
+                )
+            );
+    }
+
+    function structHash(TraitMembershipWord[] memory _self)
+        internal
+        pure
+        returns (bytes32)
+    {
+        bytes32[] memory _structHashes = new bytes32[](_self.length);
+        for (uint256 _i = 0; _i < _self.length; _i++) {
+            _structHashes[_i] = _self[_i].structHash();
+        }
+        return keccak256(abi.encodePacked(_structHashes));
     }
 }

--- a/scripts/gas.js
+++ b/scripts/gas.js
@@ -41,7 +41,7 @@ TEST_CASES.push(async function* oracleTraitMemberships(props) {
   }
 
   {
-    const msg = sdk.oracle.buildAddTraitMemberships({ traitId, tokenIds: [] });
+    const msg = { traitId, words: [] };
     const sig = await sdk.oracle.sign712.addTraitMemberships(
       signer,
       domain,
@@ -57,7 +57,7 @@ TEST_CASES.push(async function* oracleTraitMemberships(props) {
   );
 
   {
-    const msg = sdk.oracle.buildAddTraitMemberships({ traitId, tokenIds });
+    const msg = { traitId, words: sdk.oracle.traitMembershipWords(tokenIds) };
     const sig = await sdk.oracle.sign712.addTraitMemberships(
       signer,
       domain,
@@ -76,7 +76,7 @@ TEST_CASES.push(async function* oracleTraitMemberships(props) {
     .fill()
     .map((_, i) => baseTokenId + 0x0100 + i);
   {
-    const msg = sdk.oracle.buildAddTraitMemberships({ traitId, tokenIds });
+    const msg = { traitId, words: sdk.oracle.traitMembershipWords(tokenIds) };
     const sig = await sdk.oracle.sign712.addTraitMemberships(
       signer,
       domain,
@@ -90,7 +90,7 @@ TEST_CASES.push(async function* oracleTraitMemberships(props) {
     .fill()
     .map((_, i) => baseTokenId + 0x0200 + i * 8);
   {
-    const msg = sdk.oracle.buildAddTraitMemberships({ traitId, tokenIds });
+    const msg = { traitId, words: sdk.oracle.traitMembershipWords(tokenIds) };
     const sig = await sdk.oracle.sign712.addTraitMemberships(
       signer,
       domain,

--- a/scripts/gas.js
+++ b/scripts/gas.js
@@ -41,7 +41,7 @@ TEST_CASES.push(async function* oracleTraitMemberships(props) {
   }
 
   {
-    const msg = { traitId, tokenIds: [] };
+    const msg = sdk.oracle.buildAddTraitMemberships({ traitId, tokenIds: [] });
     const sig = await sdk.oracle.sign712.addTraitMemberships(
       signer,
       domain,
@@ -57,7 +57,7 @@ TEST_CASES.push(async function* oracleTraitMemberships(props) {
   );
 
   {
-    const msg = { traitId, tokenIds };
+    const msg = sdk.oracle.buildAddTraitMemberships({ traitId, tokenIds });
     const sig = await sdk.oracle.sign712.addTraitMemberships(
       signer,
       domain,
@@ -76,7 +76,7 @@ TEST_CASES.push(async function* oracleTraitMemberships(props) {
     .fill()
     .map((_, i) => baseTokenId + 0x0100 + i);
   {
-    const msg = { traitId, tokenIds };
+    const msg = sdk.oracle.buildAddTraitMemberships({ traitId, tokenIds });
     const sig = await sdk.oracle.sign712.addTraitMemberships(
       signer,
       domain,
@@ -90,7 +90,7 @@ TEST_CASES.push(async function* oracleTraitMemberships(props) {
     .fill()
     .map((_, i) => baseTokenId + 0x0200 + i * 8);
   {
-    const msg = { traitId, tokenIds };
+    const msg = sdk.oracle.buildAddTraitMemberships({ traitId, tokenIds });
     const sig = await sdk.oracle.sign712.addTraitMemberships(
       signer,
       domain,

--- a/sdk/oracle.js
+++ b/sdk/oracle.js
@@ -34,7 +34,11 @@ const SetFeatureInfoMessage = [
 ];
 const AddTraitMembershipsMessage = [
   { type: "uint256", name: "traitId" },
-  { type: "uint256[]", name: "tokenIds" },
+  { type: "TraitMembershipWord[]", name: "words" },
+];
+const TraitMembershipWord = [
+  { type: "uint256", name: "wordIndex" },
+  { type: "uint256", name: "mask" },
 ];
 
 const sign712 = Object.freeze({
@@ -55,11 +59,36 @@ const sign712 = Object.freeze({
   addTraitMemberships(signer, domainInfo, msg) {
     return signer._signTypedData(
       domainSeparator(domainInfo),
-      { AddTraitMembershipsMessage },
+      { AddTraitMembershipsMessage, TraitMembershipWord },
       msg
     );
   },
 });
+
+function buildAddTraitMemberships(msg) {
+  msg = { ...msg };
+  if (msg.tokenIds == null && msg.words != null) {
+    return msg;
+  }
+  if (msg.tokenIds != null && msg.words == null) {
+    const relativeIds = msg.tokenIds
+      .map((id) => ethers.BigNumber.from(id).mod(PROJECT_STRIDE).toBigInt())
+      .sort((a, b) => Number(a - b));
+    const wordsByIndex = {};
+    for (const id of relativeIds) {
+      const idx = id >> 8n;
+      wordsByIndex[idx] = wordsByIndex[idx] || { wordIndex: idx, mask: 0n };
+      wordsByIndex[idx].mask |= 1n << (id & 0xffn);
+    }
+    msg.words = Object.values(wordsByIndex).map((o) => ({
+      wordIndex: ethers.BigNumber.from(o.wordIndex),
+      mask: ethers.BigNumber.from(o.mask),
+    }));
+    delete msg.tokenIds;
+    return msg;
+  }
+  throw new Error("must specify exactly one of `tokenIds` or `words`");
+}
 
 function projectTraitId(projectId, version) {
   const blob = ethers.utils.defaultAbiCoder.encode(
@@ -83,6 +112,7 @@ module.exports = {
   PROJECT_STRIDE,
   domainSeparator,
   sign712,
+  buildAddTraitMemberships,
   projectTraitId,
   featureTraitId,
 };

--- a/test/ArtblocksTraitOracle.test.js
+++ b/test/ArtblocksTraitOracle.test.js
@@ -25,6 +25,7 @@ async function setFeatureInfo(oracle, signer, msg) {
 }
 
 async function addTraitMemberships(oracle, signer, msg) {
+  msg = sdk.oracle.buildAddTraitMemberships(msg);
   const domain = await domainInfo(oracle.address);
   const sig = await sdk.oracle.sign712.addTraitMemberships(signer, domain, msg);
   return oracle.addTraitMemberships(msg, sig, SignatureKind.EIP_712);
@@ -382,13 +383,19 @@ describe("ArtblocksTraitOracle", () => {
       const msg = { projectId, featureName, version };
       await setFeatureInfo(oracle, signer, msg);
 
-      const msg1 = { traitId, tokenIds: [1, 2] };
+      const msg1 = sdk.oracle.buildAddTraitMemberships({
+        traitId,
+        tokenIds: [1, 2],
+      });
       const sig1 = await sdk.oracle.sign712.addTraitMemberships(
         signer,
         await domainInfo(oracle.address),
         msg1
       );
-      const msg2 = { traitId, tokenIds: [3, 4] };
+      const msg2 = sdk.oracle.buildAddTraitMemberships({
+        traitId,
+        tokenIds: [3, 4],
+      });
       await expect(
         oracle.addTraitMemberships(msg2, sig1, SignatureKind.EIP_712)
       ).to.be.revertedWith(Errors.UNAUTHORIZED);

--- a/test/ArtblocksTraitOracle.test.js
+++ b/test/ArtblocksTraitOracle.test.js
@@ -25,7 +25,9 @@ async function setFeatureInfo(oracle, signer, msg) {
 }
 
 async function addTraitMemberships(oracle, signer, msg) {
-  msg = sdk.oracle.buildAddTraitMemberships(msg);
+  if (msg.words == null) {
+    msg = { ...msg, words: sdk.oracle.traitMembershipWords(msg.tokenIds) };
+  }
   const domain = await domainInfo(oracle.address);
   const sig = await sdk.oracle.sign712.addTraitMemberships(signer, domain, msg);
   return oracle.addTraitMemberships(msg, sig, SignatureKind.EIP_712);
@@ -383,19 +385,19 @@ describe("ArtblocksTraitOracle", () => {
       const msg = { projectId, featureName, version };
       await setFeatureInfo(oracle, signer, msg);
 
-      const msg1 = sdk.oracle.buildAddTraitMemberships({
+      const msg1 = {
         traitId,
-        tokenIds: [1, 2],
-      });
+        words: sdk.oracle.traitMembershipWords([1, 2]),
+      };
       const sig1 = await sdk.oracle.sign712.addTraitMemberships(
         signer,
         await domainInfo(oracle.address),
         msg1
       );
-      const msg2 = sdk.oracle.buildAddTraitMemberships({
+      const msg2 = {
         traitId,
-        tokenIds: [3, 4],
-      });
+        words: sdk.oracle.traitMembershipWords([3, 4]),
+      };
       await expect(
         oracle.addTraitMemberships(msg2, sig1, SignatureKind.EIP_712)
       ).to.be.revertedWith(Errors.UNAUTHORIZED);


### PR DESCRIPTION
External callers are now expected to provide trait membership data in
the same bit-packed form used for storage internally. This is cheaper
for two reasons. First, it makes the calldata much smaller: previously,
each token ID took up a full word, of which at least 236 bytes were
zero, costing between 1024 and 1252 gas per token ID. Now, each marginal
token ID costs just one set bit, at a marginal cost of 12 gas. Second,
the contract has less busy work to do: it operates on a whole storage
word at once instead of masking in one bit at a time from the input.

This is a change to the contract interface, but the trait oracle SDK
provides a convenience function to convert a message with explicit token
IDs to a packed message.

This also suggests a natural way to handle efficient finalization:
adjoin to `TraitMembershipWord` a `bool finalized` field that finalizes
a single word at a time. Finalization states can themselves be packed
into bitsets, so each storage word describes the finalization state of
65536 token IDs (and in practice we shouldn't need more than one such
storage word), and a project with mint cap `n` can be considered
effectively finalized if its first `ceiling(n / 256.0)` trait membership
words are finalized.

Gas metrics, per `node scripts/gas.js`:

test case             | before  | after  | saved (gas) | saved (%)
----------------------|--------:|-------:|------------:|---------:
Paddle (12)           | 118817  | 108436 | 10381       | 1.10×
Paddle (again; no-op) | 56299   | 47101  | 9198        | 1.20×
256 consecutive       | 290955  | 49872  | 241083      | 5.83×
256 scattered         | 465322  | 242013 | 223309      | 1.92×

wchargin-branch: oracle-bitpack-input-messages
